### PR TITLE
Don't set lens on self.cam.node()

### DIFF
--- a/scenesim/display/viewer.py
+++ b/scenesim/display/viewer.py
@@ -72,7 +72,6 @@ class Viewer(ShowBase, object):
         self.camera.reparentTo(self.cameras)
         # Adjust the camera's lens
         lens = PerspectiveLens()
-        self.cam.node().setLens(lens)
         self.camLens = lens
         self.camLens.setNearFar(0.01, 1000.0)
         #


### PR DESCRIPTION
The line `self.cam.node().setLens(lens)` causes weird rendering issues on OSX, and doesn't seem to make a difference otherwise, as far as I can tell. Here is what it looks like with that line:

![screenshot-thu-aug-29-14-53-08-2013-312](https://f.cloud.github.com/assets/83444/1053715/901a3c9c-10f5-11e3-8bb4-dbb09eeccfd8.jpg)

And without it:

![screenshot-thu-aug-29-14-53-43-2013-338](https://f.cloud.github.com/assets/83444/1053717/932f8fcc-10f5-11e3-845e-a3fd1b7c2b62.jpg)
