### PR TITLE
Add config option to set camera lens

### DIFF
--- a/scenesim/cfg/Config.prc
+++ b/scenesim/cfg/Config.prc
@@ -5,3 +5,4 @@ enforce-attrib-lock 0
 # scenesim-specific variables
 viewer-use-shaders #t
 viewer-resize-window #t
+viewer-set-cam-lens #t

--- a/scenesim/display/viewer.py
+++ b/scenesim/display/viewer.py
@@ -75,7 +75,9 @@ class Viewer(ShowBase, object):
         lens = PerspectiveLens()
         self.camLens = lens
         self.camLens.setNearFar(0.01, 1000.0)
-        self.cam.node().setLens(self.camLens)
+        setlens = ConfigVariableBool('viewer-set-cam-lens', '#t')
+        if setlens:
+            self.cam.node().setLens(self.camLens)
         #
         # Initialize / set variables
         self.sso = None


### PR DESCRIPTION
Setting the camera lens causes the view to look "squished" on OSX and so the line was removed by #5, but apparently this causes issues on linux because it was reintroduced in c4b7eb98d8d5f6611c9240e256a07737c106e9ec. This commit adds a configuration variable to control whether the lens is set, so people on linux can set it to true (the default) and people on Mac can set it to false.
