### PR TITLE
Add option to not set antialiasing

### DIFF
--- a/scenesim/cfg/Config0.prc
+++ b/scenesim/cfg/Config0.prc
@@ -11,5 +11,6 @@ garbage-collect-states 0
 viewer-use-shaders #t
 viewer-resize-window #t
 viewer-set-cam-lens #t
+viewer-use-antialiasing #t
 
 bullet-filter-algorithm	groups-mask

--- a/scenesim/display/viewer.py
+++ b/scenesim/display/viewer.py
@@ -68,7 +68,9 @@ class Viewer(ShowBase, object):
         if use_shaders:
             self.render.setShaderAuto()
         # Set antialiasing on
-        self.render.setAntialias(AntialiasAttrib.MAuto)
+        use_aa = ConfigVariableBool('viewer-use-antialiasing', '#t')
+        if use_aa.getValue():
+            self.render.setAntialias(AntialiasAttrib.MAuto)
         # Camera
         self.camera_rot = self.render.attachNewNode("camera_rot")
         self.cameras = self.camera_rot.attachNewNode("cameras")


### PR DESCRIPTION
Sometimes antialiasing causes unwanted effects, for example on linux, the mesh of my floor model is visible when antialiasing is turned on:

![screenshot-fri-mar-14-14-58-48-2014-63](https://f.cloud.github.com/assets/83444/2426340/ef094130-abc3-11e3-8c3f-9c99c8d244e5.jpg)

This pull request just adds a new configuration option (default set to true) for whether to turn on antialiasing or not.
